### PR TITLE
Add Next.js habit tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
-# habbit
-Habit tracker
+# Habbit
+
+Next.js ve Tailwind CSS kullanılarak hazırlanmış basit bir alışkanlık takip uygulaması.
+
+## Kurulum
+
+1. Bağımlılıkları yükleyin:
+   ```bash
+   npm install
+   ```
+2. Geliştirme sunucusunu başlatın:
+   ```bash
+   npm run dev
+   ```
+3. Tarayıcınızdan `http://localhost:3000` adresine giderek uygulamayı kullanabilirsiniz.
+
+Alışkanlıklar tarayıcıdaki `localStorage` üzerinde saklanır.
+

--- a/app/add/page.tsx
+++ b/app/add/page.tsx
@@ -1,0 +1,12 @@
+import HabitForm from '../../components/HabitForm';
+import Link from 'next/link';
+
+export default function AddPage() {
+  return (
+    <main className="max-w-xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold text-center">Alışkanlık Ekle</h1>
+      <HabitForm />
+      <Link href="/" className="text-blue-600 block text-center">Geri</Link>
+    </main>
+  );
+}

--- a/app/edit/[id]/page.tsx
+++ b/app/edit/[id]/page.tsx
@@ -1,0 +1,18 @@
+import { notFound } from 'next/navigation';
+import HabitForm from '../../../components/HabitForm';
+import { loadHabits } from '../../../lib/storage';
+import Link from 'next/link';
+
+export default function EditPage({ params }: { params: { id: string } }) {
+  const habits = loadHabits();
+  const habit = habits.find(h => h.id === Number(params.id));
+  if (!habit) return notFound();
+
+  return (
+    <main className="max-w-xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold text-center">Alışkanlığı Düzenle</h1>
+      <HabitForm habit={habit} />
+      <Link href="/" className="text-blue-600 block text-center">Geri</Link>
+    </main>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-100 p-4;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,18 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import { Inter } from 'next/font/google';
+
+const inter = Inter({ subsets: ['latin'] });
+
+export const metadata: Metadata = {
+  title: 'Habit Tracker',
+  description: 'Basit Next.js alışkanlık takip uygulaması',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="tr">
+      <body className={inter.className}>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+import HabitList from '../components/HabitList';
+
+export default function Home() {
+  return (
+    <main className="max-w-xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold text-center">Alışkanlıklar</h1>
+      <Link href="/add" className="bg-green-600 text-white px-4 py-2 block text-center rounded">
+        Yeni Alışkanlık Ekle
+      </Link>
+      <HabitList />
+    </main>
+  );
+}

--- a/components/HabitForm.tsx
+++ b/components/HabitForm.tsx
@@ -1,0 +1,75 @@
+'use client';
+import { useState } from 'react';
+import { Habit, loadHabits, saveHabits, getPeriodStart } from '../lib/storage';
+import { useRouter } from 'next/navigation';
+
+export default function HabitForm({ habit }: { habit?: Habit }) {
+  const router = useRouter();
+  const [name, setName] = useState(habit?.name || '');
+  const [color, setColor] = useState(habit?.color || '#3498db');
+  const [target, setTarget] = useState(habit?.target || 1);
+  const [frequency, setFrequency] = useState<Habit['frequency']>(habit?.frequency || 'daily');
+
+  const save = () => {
+    const habits = loadHabits();
+    if (habit) {
+      const h = habits.find(h => h.id === habit.id);
+      if (h) {
+        h.name = name;
+        h.color = color;
+        h.target = target;
+        h.frequency = frequency;
+      }
+    } else {
+      habits.push({
+        id: Date.now(),
+        name,
+        color,
+        target,
+        frequency,
+        count: 0,
+        lastReset: getPeriodStart(Date.now(), frequency),
+      });
+    }
+    saveHabits(habits);
+    router.push('/');
+  };
+
+  const deleteHabit = () => {
+    if (!habit) return;
+    const habits = loadHabits().filter(h => h.id !== habit.id);
+    saveHabits(habits);
+    router.push('/');
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block mb-1">İsim</label>
+        <input className="border p-2 w-full" value={name} onChange={e => setName(e.target.value)} />
+      </div>
+      <div>
+        <label className="block mb-1">Renk</label>
+        <input type="color" className="w-16 h-10" value={color} onChange={e => setColor(e.target.value)} />
+      </div>
+      <div>
+        <label className="block mb-1">Tekrar Sayısı</label>
+        <input type="number" className="border p-2 w-full" min="1" value={target} onChange={e => setTarget(parseInt(e.target.value))} />
+      </div>
+      <div>
+        <label className="block mb-1">Aralık</label>
+        <select className="border p-2 w-full" value={frequency} onChange={e => setFrequency(e.target.value as any)}>
+          <option value="daily">Günlük</option>
+          <option value="weekly">Haftalık</option>
+          <option value="monthly">Aylık</option>
+        </select>
+      </div>
+      <div className="flex gap-2">
+        <button className="bg-blue-600 text-white px-4 py-2" onClick={save}>Kaydet</button>
+        {habit && (
+          <button className="bg-red-600 text-white px-4 py-2" onClick={deleteHabit}>Sil</button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/HabitList.tsx
+++ b/components/HabitList.tsx
@@ -1,0 +1,84 @@
+'use client';
+import { Habit, loadHabits, saveHabits, resetIfNeeded } from '../lib/storage';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+export default function HabitList() {
+  const [habits, setHabits] = useState<Habit[]>([]);
+
+  useEffect(() => {
+    const h = loadHabits();
+    h.forEach(resetIfNeeded);
+    saveHabits(h);
+    setHabits([...h]);
+  }, []);
+
+  const update = (id: number, delta: number) => {
+    const h = loadHabits();
+    const habit = h.find(x => x.id === id);
+    if (!habit) return;
+    resetIfNeeded(habit);
+    habit.count = Math.max(0, Math.min(habit.target, habit.count + delta));
+    saveHabits(h);
+    setHabits([...h]);
+  };
+
+  const groups: Record<Habit['frequency'], Habit[]> = {
+    daily: [],
+    weekly: [],
+    monthly: [],
+  };
+  habits.forEach(h => groups[h.frequency].push(h));
+
+  const titles: Record<Habit['frequency'], string> = {
+    daily: 'Günlük',
+    weekly: 'Haftalık',
+    monthly: 'Aylık',
+  };
+
+  return (
+    <div className="space-y-6">
+      {(['daily', 'weekly', 'monthly'] as Habit['frequency'][]).map(freq => (
+        <div key={freq}>
+          <h2 className="text-xl font-semibold mb-2">{titles[freq]}</h2>
+          <div className="space-y-2">
+            {groups[freq].map(h => (
+              <div
+                key={h.id}
+                className="p-2 rounded text-white flex justify-between items-center"
+                style={{ backgroundColor: h.color }}
+              >
+                <span>
+                  {h.name} ({h.count}/{h.target})
+                </span>
+                <div className="space-x-1">
+                  <button
+                    className="bg-black/30 px-2"
+                    onClick={() => update(h.id, -1)}
+                  >
+                    -
+                  </button>
+                  <button
+                    className="bg-black/30 px-2"
+                    onClick={() => update(h.id, 1)}
+                  >
+                    +
+                  </button>
+                  <Link
+                    href={`/edit/${h.id}`}
+                    className="bg-black/30 px-2"
+                  >
+                    ✏️
+                  </Link>
+                </div>
+              </div>
+            ))}
+            {groups[freq].length === 0 && (
+              <p className="text-gray-500">Alışkanlık yok</p>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,0 +1,45 @@
+export type Habit = {
+  id: number;
+  name: string;
+  color: string;
+  target: number;
+  frequency: 'daily' | 'weekly' | 'monthly';
+  count: number;
+  lastReset: number;
+};
+
+export function loadHabits(): Habit[] {
+  if (typeof window === 'undefined') return [];
+  const data = localStorage.getItem('habits');
+  return data ? JSON.parse(data) : [];
+}
+
+export function saveHabits(habits: Habit[]) {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem('habits', JSON.stringify(habits));
+}
+
+export function getPeriodStart(date: number, freq: Habit['frequency']) {
+  const d = new Date(date);
+  if (freq === 'daily') {
+    d.setHours(0, 0, 0, 0);
+  } else if (freq === 'weekly') {
+    const day = d.getDay();
+    const diff = d.getDate() - day + (day === 0 ? -6 : 1);
+    d.setDate(diff);
+    d.setHours(0, 0, 0, 0);
+  } else {
+    d.setDate(1);
+    d.setHours(0, 0, 0, 0);
+  }
+  return d.getTime();
+}
+
+export function resetIfNeeded(habit: Habit) {
+  const now = Date.now();
+  const start = getPeriodStart(now, habit.frequency);
+  if (habit.lastReset !== start) {
+    habit.count = 0;
+    habit.lastReset = start;
+  }
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true,
+  },
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "habbit-next",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "tailwindcss": "^3.4.5",
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.21"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./app/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- switch project to Next.js with Tailwind CSS
- implement habit list, add, and edit views using React components
- store habits in localStorage
- update README with setup instructions

## Testing
- `node --version`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_6840025d829c832386fdb402bc0dab87