### PR TITLE
Use shadcn-style components

### DIFF
--- a/app/add/page.tsx
+++ b/app/add/page.tsx
@@ -1,12 +1,17 @@
 import HabitForm from '../../components/HabitForm';
 import Link from 'next/link';
+import { Card, CardContent } from '../../components/ui/card';
 
 export default function AddPage() {
   return (
     <main className="max-w-xl mx-auto space-y-4">
       <h1 className="text-2xl font-bold text-center">Alışkanlık Ekle</h1>
-      <HabitForm />
-      <Link href="/" className="text-blue-600 block text-center">Geri</Link>
+      <Card>
+        <CardContent>
+          <HabitForm />
+        </CardContent>
+      </Card>
+      <Link href="/" className="text-blue-600 block text-center hover:underline">Geri</Link>
     </main>
   );
 }

--- a/app/edit/[id]/page.tsx
+++ b/app/edit/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation';
 import HabitForm from '../../../components/HabitForm';
 import { loadHabits } from '../../../lib/storage';
 import Link from 'next/link';
+import { Card, CardContent } from '../../../components/ui/card';
 
 export default function EditPage({ params }: { params: { id: string } }) {
   const habits = loadHabits();
@@ -11,8 +12,12 @@ export default function EditPage({ params }: { params: { id: string } }) {
   return (
     <main className="max-w-xl mx-auto space-y-4">
       <h1 className="text-2xl font-bold text-center">Alışkanlığı Düzenle</h1>
-      <HabitForm habit={habit} />
-      <Link href="/" className="text-blue-600 block text-center">Geri</Link>
+      <Card>
+        <CardContent>
+          <HabitForm habit={habit} />
+        </CardContent>
+      </Card>
+      <Link href="/" className="text-blue-600 block text-center hover:underline">Geri</Link>
     </main>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,5 +3,5 @@
 @tailwind utilities;
 
 body {
-  @apply bg-gray-100 p-4;
+  @apply bg-gray-100 p-4 min-h-screen;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="tr">
-      <body className={inter.className}>{children}</body>
+      <body className={`${inter.className} text-gray-900`}>{children}</body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,20 @@
 import Link from 'next/link';
 import HabitList from '../components/HabitList';
+import { Card, CardContent } from '../components/ui/card';
+import { Button } from '../components/ui/button';
 
 export default function Home() {
   return (
     <main className="max-w-xl mx-auto space-y-4">
       <h1 className="text-2xl font-bold text-center">Alışkanlıklar</h1>
-      <Link href="/add" className="bg-green-600 text-white px-4 py-2 block text-center rounded">
-        Yeni Alışkanlık Ekle
-      </Link>
-      <HabitList />
+      <Button asChild className="bg-green-600 hover:bg-green-700 w-full">
+        <Link href="/add">Yeni Alışkanlık Ekle</Link>
+      </Button>
+      <Card>
+        <CardContent>
+          <HabitList />
+        </CardContent>
+      </Card>
     </main>
   );
 }

--- a/components/HabitForm.tsx
+++ b/components/HabitForm.tsx
@@ -2,6 +2,9 @@
 import { useState } from 'react';
 import { Habit, loadHabits, saveHabits, getPeriodStart } from '../lib/storage';
 import { useRouter } from 'next/navigation';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Select } from './ui/select';
 
 export default function HabitForm({ habit }: { habit?: Habit }) {
   const router = useRouter();
@@ -46,28 +49,28 @@ export default function HabitForm({ habit }: { habit?: Habit }) {
     <div className="space-y-4">
       <div>
         <label className="block mb-1">İsim</label>
-        <input className="border p-2 w-full" value={name} onChange={e => setName(e.target.value)} />
+        <Input value={name} onChange={e => setName(e.target.value)} />
       </div>
       <div>
         <label className="block mb-1">Renk</label>
-        <input type="color" className="w-16 h-10" value={color} onChange={e => setColor(e.target.value)} />
+        <Input type="color" className="w-16 h-10" value={color} onChange={e => setColor(e.target.value)} />
       </div>
       <div>
         <label className="block mb-1">Tekrar Sayısı</label>
-        <input type="number" className="border p-2 w-full" min="1" value={target} onChange={e => setTarget(parseInt(e.target.value))} />
+        <Input type="number" min="1" value={target} onChange={e => setTarget(parseInt(e.target.value))} />
       </div>
       <div>
         <label className="block mb-1">Aralık</label>
-        <select className="border p-2 w-full" value={frequency} onChange={e => setFrequency(e.target.value as any)}>
+        <Select value={frequency} onChange={e => setFrequency(e.target.value as any)}>
           <option value="daily">Günlük</option>
           <option value="weekly">Haftalık</option>
           <option value="monthly">Aylık</option>
-        </select>
+        </Select>
       </div>
       <div className="flex gap-2">
-        <button className="bg-blue-600 text-white px-4 py-2" onClick={save}>Kaydet</button>
+        <Button onClick={save}>Kaydet</Button>
         {habit && (
-          <button className="bg-red-600 text-white px-4 py-2" onClick={deleteHabit}>Sil</button>
+          <Button className="bg-red-600 hover:bg-red-700" onClick={deleteHabit}>Sil</Button>
         )}
       </div>
     </div>

--- a/components/HabitList.tsx
+++ b/components/HabitList.tsx
@@ -2,6 +2,7 @@
 import { Habit, loadHabits, saveHabits, resetIfNeeded } from '../lib/storage';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
+import { Button } from './ui/button';
 
 export default function HabitList() {
   const [habits, setHabits] = useState<Habit[]>([]);
@@ -45,28 +46,28 @@ export default function HabitList() {
             {groups[freq].map(h => (
               <div
                 key={h.id}
-                className="p-2 rounded text-white flex justify-between items-center"
+                className="p-3 rounded-lg text-white flex justify-between items-center shadow"
                 style={{ backgroundColor: h.color }}
               >
-                <span>
+                <span className="font-medium">
                   {h.name} ({h.count}/{h.target})
                 </span>
                 <div className="space-x-1">
-                  <button
-                    className="bg-black/30 px-2"
+                  <Button
+                    className="bg-black/30 hover:bg-black/40 px-2 py-1"
                     onClick={() => update(h.id, -1)}
                   >
                     -
-                  </button>
-                  <button
-                    className="bg-black/30 px-2"
+                  </Button>
+                  <Button
+                    className="bg-black/30 hover:bg-black/40 px-2 py-1"
                     onClick={() => update(h.id, 1)}
                   >
                     +
-                  </button>
+                  </Button>
                   <Link
                     href={`/edit/${h.id}`}
-                    className="bg-black/30 px-2"
+                    className="bg-black/30 hover:bg-black/40 px-2 py-1 rounded transition-colors"
                   >
                     ✏️
                   </Link>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, asChild = false, children, ...props }, ref) => {
+    const base = cn(
+      'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none bg-blue-600 text-white hover:bg-blue-700',
+      className,
+    );
+
+    if (asChild && React.isValidElement(children)) {
+      return React.cloneElement(children, {
+        ref,
+        className: cn(base, children.props.className),
+        ...props,
+      });
+    }
+
+    return (
+      <button ref={ref} className={base} {...props}>
+        {children}
+      </button>
+    );
+  },
+);
+Button.displayName = 'Button';
+
+export { Button };

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,10 @@
+import { cn } from '../../lib/utils';
+import * as React from 'react';
+
+export function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('rounded-lg border bg-white text-gray-900 shadow', className)} {...props} />;
+}
+
+export function CardContent({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('p-4', className)} {...props} />;
+}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        ref={ref}
+        className={cn(
+          'flex h-10 w-full rounded-md border border-input bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = 'Input';
+
+export { Input };

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {}
+
+const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <select
+        ref={ref}
+        className={cn(
+          'flex h-10 w-full rounded-md border border-input bg-white px-3 py-2 text-sm ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+Select.displayName = 'Select';
+
+export { Select };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | undefined | false | null)[]) {
+  return classes.filter(Boolean).join(' ');
+}


### PR DESCRIPTION
## Summary
- implement simple `cn` util
- create shadcn-like `Button`, `Input`, `Select`, and `Card` components
- restyle forms and pages to use new components

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400902a64883239139f34809c8f516