### PR TITLE
Add predefined color options

### DIFF
--- a/components/HabitForm.tsx
+++ b/components/HabitForm.tsx
@@ -11,6 +11,16 @@ export default function HabitForm({ habit }: { habit?: Habit }) {
   const router = useRouter();
   const [name, setName] = useState(habit?.name || '');
   const [color, setColor] = useState(habit?.color || '#3498db');
+  const colors = [
+    '#3498db',
+    '#e74c3c',
+    '#2ecc71',
+    '#f1c40f',
+    '#9b59b6',
+    '#1abc9c',
+    '#e67e22',
+    '#95a5a6',
+  ];
   const [target, setTarget] = useState(habit?.target || 1);
   const [frequency, setFrequency] = useState<Habit['frequency']>(habit?.frequency || 'daily');
 
@@ -54,7 +64,17 @@ export default function HabitForm({ habit }: { habit?: Habit }) {
       </div>
       <div className="space-y-1">
         <Label>Renk</Label>
-        <Input type="color" className="w-16 h-10" value={color} onChange={e => setColor(e.target.value)} />
+        <div className="flex flex-wrap gap-2">
+          {colors.map(c => (
+            <button
+              key={c}
+              type="button"
+              className={`w-8 h-8 rounded-full border-2 ${color === c ? 'border-black' : 'border-transparent'}`}
+              style={{ backgroundColor: c }}
+              onClick={() => setColor(c)}
+            />
+          ))}
+        </div>
       </div>
       <div className="space-y-1">
         <Label>Tekrar Sayısı</Label>


### PR DESCRIPTION
## Summary
- add list of eight preset colors in `HabitForm`
- show selectable color swatches instead of the color picker

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68400ef2e39083239b7cf128b77835f7